### PR TITLE
chore: github action node v

### DIFF
--- a/.github/workflows/check-building-blog.yml
+++ b/.github/workflows/check-building-blog.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '19.x'
+          node-version: '19.4'
           cache: yarn
       - name: ci
         run: yarn

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '19.x'
+          node-version: '19.4'
           cache: yarn
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## 目的

github action が node の新しいバージョンで落ちるのでちょっと戻してみる
(local では 19.4 で動いた)

## 影響

## 作業内容

